### PR TITLE
Add autofree vtest flags to generic math test

### DIFF
--- a/vlib/v/tests/autofree_generic_math_test.v
+++ b/vlib/v/tests/autofree_generic_math_test.v
@@ -1,5 +1,5 @@
 // vtest vflags: -autofree
-
+// vtest build: !sanitize-address-gcc && !sanitize-address-clang
 // Test for memory leak fix when using generics with math.min/max and autofree
 module main
 

--- a/vlib/v/tests/autofree_generic_math_test.v
+++ b/vlib/v/tests/autofree_generic_math_test.v
@@ -1,3 +1,5 @@
+// vtest vflags: -autofree
+
 // Test for memory leak fix when using generics with math.min/max and autofree
 module main
 


### PR DESCRIPTION
Add vtest flags for autofree in the test file.